### PR TITLE
FoxGooseBagOfCornSpec

### DIFF
--- a/FoxGooseBagOfCorn/src/main/scala/FoxGooseBagofCorn.scala
+++ b/FoxGooseBagOfCorn/src/main/scala/FoxGooseBagofCorn.scala
@@ -1,2 +1,17 @@
 object FoxGooseBagofCorn {
+
+  object FoxGooseCornYou extends Enumeration {
+    val fox, goose, corn, you = Value
+    val empty = ValueSet.empty
+  }
+
+  import FoxGooseCornYou._
+
+  val startPos = Seq(
+    fox + goose + corn + you /*left bank*/ ,
+    empty /*boat*/ ,
+    empty /*right bank*/
+  )
+
+  def riverCrossingPlan: Seq[Seq[ValueSet]] = Seq(startPos)
 }

--- a/FoxGooseBagOfCorn/src/test/scala/FoxGooseBagofCornSpec.scala
+++ b/FoxGooseBagOfCorn/src/test/scala/FoxGooseBagofCornSpec.scala
@@ -1,0 +1,63 @@
+import FoxGooseBagofCorn._
+import org.scalatest._
+
+class FoxGooseBagofCornSpec extends WordSpec {
+
+  import FoxGooseCornYou._
+
+  "river crossing plan" when {
+    val crossingPlan = riverCrossingPlan
+
+    "you begin with the fox, goose and corn on one side of the river" in {
+      assert(crossingPlan.head == Seq(you + fox + goose + corn, empty, empty))
+    }
+
+    "you end with the fox, goose and corn on one side of the river" in {
+      assert(crossingPlan.last == Seq(empty, empty, you + fox + goose + corn))
+    }
+
+    "things are safe" when {
+      val leftBank = crossingPlan map (_.head)
+      val rightBank = crossingPlan map (_.last)
+
+      "the fox and the goose should never be left alone together" in {
+        assert(!((leftBank ++ rightBank) contains (fox + goose)))
+      }
+
+      "the goose and the corn should never be left alone together" in {
+        assert(!((leftBank ++ rightBank) contains (goose + corn)))
+      }
+    }
+
+    "The boat can carry only you plus one other" in {
+      val boatPositions = crossingPlan map (_ (2))
+      assert(!(boatPositions exists (_.size > 2)))
+    }
+
+    "moves are valid" in {
+      val leftMoves = crossingPlan map (_.head)
+      val middleMoves = crossingPlan map (_ (2))
+      val rightMoves = crossingPlan map (_.last)
+
+      def validateMove(step1: ValueSet, step2: ValueSet) {
+        val diff1 = step1 diff step2
+        val diff2 = step2 diff step1
+        val diffs = diff1 ++ diff2
+        val diffNum = diffs.size
+        assert(diffNum < 3, "only you and another thing can move")
+        if (diffNum > 0)
+          assert(diffs contains you, "only you and another thing can move")
+      }
+      def validateMoves(moves: Seq[ValueSet]) {
+        moves sliding 2 foreach {
+          case Seq(step1, step2) => validateMove(step1, step2)
+          case _ =>
+        }
+      }
+
+      validateMoves(leftMoves)
+      validateMoves(middleMoves)
+      validateMoves(rightMoves)
+    }
+  }
+}

--- a/FoxGooseBagOfCorn/src/test/scala/FoxGooseBagofCornSpec.scala
+++ b/FoxGooseBagOfCorn/src/test/scala/FoxGooseBagofCornSpec.scala
@@ -32,16 +32,16 @@ class FoxGooseBagofCornSpec extends WordSpec {
     }
 
     "The boat can carry only you plus one other" in {
-      val boatPositions = crossingPlan map (_ (2))
+      val boatPositions = crossingPlan map (_ (1))
       assert(!(boatPositions exists (_.size > 2)))
     }
 
     "moves are valid" in {
       val leftMoves = crossingPlan map (_.head)
-      val middleMoves = crossingPlan map (_ (2))
+      val middleMoves = crossingPlan map (_ (1))
       val rightMoves = crossingPlan map (_.last)
 
-      def validateMove(step1: ValueSet, step2: ValueSet) {
+      def validateMove(step1: ValueSet, step2: ValueSet): Unit = {
         val diff1 = step1 diff step2
         val diff2 = step2 diff step1
         val diffs = diff1 ++ diff2
@@ -50,7 +50,7 @@ class FoxGooseBagofCornSpec extends WordSpec {
         if (diffNum > 0)
           assert(diffs contains you, "only you and another thing can move")
       }
-      def validateMoves(moves: Seq[ValueSet]) {
+      def validateMoves(moves: Seq[ValueSet]): Unit = {
         moves sliding 2 foreach {
           case Seq(step1, step2) => validateMove(step1, step2)
           case _ =>

--- a/FoxGooseBagOfCorn/src/test/scala/FoxGooseBagofCornSpec.scala
+++ b/FoxGooseBagOfCorn/src/test/scala/FoxGooseBagofCornSpec.scala
@@ -20,12 +20,14 @@ class FoxGooseBagofCornSpec extends WordSpec {
       val leftBank = crossingPlan map (_.head)
       val rightBank = crossingPlan map (_.last)
 
+      def leftAloneTogether(them: ValueSet)(pos: ValueSet) = !(pos contains you) && (them subsetOf pos)
+
       "the fox and the goose should never be left alone together" in {
-        assert(!((leftBank ++ rightBank) contains (fox + goose)))
+        assert(!((leftBank ++ rightBank) exists leftAloneTogether(fox + goose)))
       }
 
       "the goose and the corn should never be left alone together" in {
-        assert(!((leftBank ++ rightBank) contains (goose + corn)))
+        assert(!((leftBank ++ rightBank) exists leftAloneTogether(goose + corn)))
       }
     }
 


### PR DESCRIPTION
I added specs and initial implementation of FoxGoose kata. There are some changes compared to the original:
- this version uses enumeration values (FoxGooseCornYou) instead of symbols
- position is represented as ValueSet
- specs contain more restrictive checks for correct positions (compare `things are safe` test with Clojure version)
